### PR TITLE
Store key as char*

### DIFF
--- a/include/lskuse/aes.h
+++ b/include/lskuse/aes.h
@@ -37,15 +37,15 @@ namespace lskuse
       AES(Mode mode, KeyLen keyLen, Padding padding);
 
       static Status encrypt(Mode mode, KeyLen keyLen, Padding padding, 
-                            const std::filesystem::path& plaintextFile, const std::string& key, 
+                            const std::filesystem::path& plaintextFile, const char* key, 
                             const std::filesystem::path& ciphertextFile);
       static Status decrypt(Mode mode, KeyLen keyLen, Padding padding, 
-                            const std::filesystem::path& ciphertextFile, const std::string& key, 
+                            const std::filesystem::path& ciphertextFile, const char* key, 
                             const std::filesystem::path& plaintextFile);
 
-      Status encrypt(const std::filesystem::path& plaintextFile, const std::string& key, 
+      Status encrypt(const std::filesystem::path& plaintextFile, const char* key, 
                      const std::filesystem::path& ciphertextFile);
-      Status decrypt(const std::filesystem::path& ciphertextFile, const std::string& key, 
+      Status decrypt(const std::filesystem::path& ciphertextFile, const char* key, 
                      const std::filesystem::path& plaintextFile);
 
     private:

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -16,7 +16,7 @@ AES::AES(Mode mode, KeyLen keyLen, Padding padding) :
 
 /*************************************************************************************************/
 AES::Status AES::encrypt(Mode mode, KeyLen keyLen, Padding padding, 
-                         const std::filesystem::path& plaintextFile, const std::string& key, 
+                         const std::filesystem::path& plaintextFile, const char* key, 
                          const std::filesystem::path& ciphertextFile)
 {
   AES aes(mode, keyLen, padding);
@@ -25,7 +25,7 @@ AES::Status AES::encrypt(Mode mode, KeyLen keyLen, Padding padding,
 
 /*************************************************************************************************/
 AES::Status AES::decrypt(Mode mode, KeyLen keyLen, Padding padding, 
-                         const std::filesystem::path& ciphertextFile, const std::string& key, 
+                         const std::filesystem::path& ciphertextFile, const char* key, 
                          const std::filesystem::path& plaintextFile)
 {
   AES aes(mode, keyLen, padding);
@@ -33,7 +33,7 @@ AES::Status AES::decrypt(Mode mode, KeyLen keyLen, Padding padding,
 }
 
 /*************************************************************************************************/
-AES::Status AES::encrypt(const std::filesystem::path& plaintextFile, const std::string& key, 
+AES::Status AES::encrypt(const std::filesystem::path& plaintextFile, const char* key, 
                          const std::filesystem::path& ciphertextFile)
 {
   Status status;
@@ -78,12 +78,6 @@ AES::Status AES::encrypt(const std::filesystem::path& plaintextFile, const std::
   }
 
   AESKeySchedule keySchedule(m_keyLen, key);
-  if(!keySchedule.isValid())
-  {
-    status.m_success = false;
-    status.m_message = "An invalid key length was provided";
-    return status;
-  }
 
   switch(m_mode)
   {
@@ -110,7 +104,7 @@ AES::Status AES::encrypt(const std::filesystem::path& plaintextFile, const std::
 }
 
 /*************************************************************************************************/
-AES::Status AES::decrypt(const std::filesystem::path& ciphertextFile, const std::string& key, 
+AES::Status AES::decrypt(const std::filesystem::path& ciphertextFile, const char* key, 
                          const std::filesystem::path& plaintextFile)
 {
   Status status;
@@ -155,12 +149,6 @@ AES::Status AES::decrypt(const std::filesystem::path& ciphertextFile, const std:
   }
 
   AESKeySchedule keySchedule(m_keyLen, key);
-  if(!keySchedule.isValid())
-  {
-    status.m_success = false;
-    status.m_message = "An invalid key length was provided";
-    return status;
-  }
   
   switch(m_mode)
   {

--- a/src/aeskeysched.cpp
+++ b/src/aeskeysched.cpp
@@ -12,12 +12,10 @@ using namespace lskuse;
  *****************************************************************************/
 
 /*************************************************************************************************/
-AESKeySchedule::AESKeySchedule(AES::KeyLen keyLen, const std::string& key) :
-  m_keyLen(keyLen),
-  m_key(key),
-  m_valid(true)
+AESKeySchedule::AESKeySchedule(AES::KeyLen keyLen, const char* key) :
+  m_keyLen(keyLen)
 {
-  computeKeySchedule();
+  computeKeySchedule(key);
 }
 
 /*************************************************************************************************/
@@ -50,38 +48,31 @@ unsigned AESKeySchedule::getNumRounds() const
 /*************************************************************************************************/
 uint8_t* AESKeySchedule::getRoundKey(unsigned round) const
 {
-  if(!isValid() || round >= m_keySchedule.size())
+  if(round >= m_keySchedule.size())
     return nullptr;
   else
     return m_keySchedule[round];
 }
 
 /*************************************************************************************************/
-void AESKeySchedule::computeKeySchedule()
+void AESKeySchedule::computeKeySchedule(const char* key)
 {
-  if((m_keyLen == AES::KeyLen::LEN_128 && m_key.size() != LEN_128_IN_BYTES) ||
-     (m_keyLen == AES::KeyLen::LEN_192 && m_key.size() != LEN_192_IN_BYTES) ||
-     (m_keyLen == AES::KeyLen::LEN_256 && m_key.size() != LEN_256_IN_BYTES))
-  {
-    m_valid = false;
-  }
-
   if(m_keyLen == AES::KeyLen::LEN_128)
-    compute128KeySchedule();
+    compute128KeySchedule(key);
   else if(m_keyLen == AES::KeyLen::LEN_192)
-    compute192KeySchedule();
+    compute192KeySchedule(key);
   else
-    compute256KeySchedule();
+    compute256KeySchedule(key);
 }
 
 /*************************************************************************************************/
-void AESKeySchedule::compute128KeySchedule()
+void AESKeySchedule::compute128KeySchedule(const char* key)
 {
   // grab the first 4 words
   unsigned wIdx = 0;
   uint8_t W[LEN_128_WORD_ARRAY_SIZE];
   for(unsigned byteIdx = 0; byteIdx < LEN_128_IN_BYTES; byteIdx++)
-    W[wIdx++] = m_key.data()[byteIdx];
+    W[wIdx++] = key[byteIdx];
 
   // apply the transformation 10 times to get a total of 11 round keys
   for(unsigned transformation = 0; transformation < LEN_128_TRANSFORMATIONS; transformation++)
@@ -112,13 +103,13 @@ void AESKeySchedule::compute128KeySchedule()
 }
 
 /*************************************************************************************************/
-void AESKeySchedule::compute192KeySchedule()
+void AESKeySchedule::compute192KeySchedule(const char* key)
 {
   // grab the first 6 words
   unsigned wIdx = 0;
   uint8_t W[LEN_192_WORD_ARRAY_SIZE];
   for(unsigned byteIdx = 0; byteIdx < LEN_192_IN_BYTES; byteIdx++)
-    W[wIdx++] = m_key.data()[byteIdx];
+    W[wIdx++] = key[byteIdx];
 
   // apply the tranformation 9 times to get a total of 13 round keys
   for(unsigned transformation = 0; transformation < LEN_192_TRANSFORMATIONS; transformation++)
@@ -149,13 +140,13 @@ void AESKeySchedule::compute192KeySchedule()
 }
 
 /*************************************************************************************************/
-void AESKeySchedule::compute256KeySchedule()
+void AESKeySchedule::compute256KeySchedule(const char* key)
 {
   // grab the first 8 words
   unsigned wIdx = 0;
   uint8_t W[LEN_256_WORD_ARRAY_SIZE];
   for(unsigned byteIdx = 0; byteIdx < LEN_256_IN_BYTES; byteIdx++)
-    W[wIdx++] = m_key.data()[byteIdx];
+    W[wIdx++] = key[byteIdx];
 
   // apply the transformation 8 times to get a total of 15 round keys
   for(unsigned transformation = 0; transformation < LEN_256_TRANSFORMATIONS; transformation++)

--- a/src/aeskeysched.h
+++ b/src/aeskeysched.h
@@ -10,18 +10,17 @@ namespace lskuse
   class AESKeySchedule
   {
     public:
-      AESKeySchedule(AES::KeyLen keyLen, const std::string& key);
+      AESKeySchedule(AES::KeyLen keyLen, const char* key);
       ~AESKeySchedule();
 
-      inline bool isValid() const {return m_valid;}
       unsigned getNumRounds() const;
       uint8_t* getRoundKey(unsigned round) const;
 
     private:
-      void computeKeySchedule();
-      void compute128KeySchedule();
-      void compute192KeySchedule();
-      void compute256KeySchedule();
+      void computeKeySchedule(const char* key);
+      void compute128KeySchedule(const char* key);
+      void compute192KeySchedule(const char* key);
+      void compute256KeySchedule(const char* key);
       void rotWord(uint8_t* word);
       void subWord(uint8_t* word);
       void rcon(uint8_t* word, unsigned round);
@@ -39,8 +38,6 @@ namespace lskuse
       static constexpr const unsigned LEN_256_TRANSFORMATIONS = LEN_256_WORD_ARRAY_SIZE / LEN_256_IN_BYTES - 1;
 
       AES::KeyLen           m_keyLen;
-      std::string           m_key;
-      bool                  m_valid;
       std::vector<uint8_t*> m_keySchedule;
 
       /************************************************************************

--- a/tests/test_aeskeysched.cpp
+++ b/tests/test_aeskeysched.cpp
@@ -17,7 +17,7 @@ namespace lskuse
   {
     TEST(AESKeyScheduleTest, test128KeySchedule)
     {
-      char origKey[17];
+      char origKey[16];
       origKey[0] = 0x2b;
       origKey[1] = 0x7e;
       origKey[2] = 0x15;
@@ -34,7 +34,6 @@ namespace lskuse
       origKey[13] = 0xcf; 
       origKey[14] = 0x4f;
       origKey[15] = 0x3c;
-      origKey[16] = '\0';
 
       AESKeySchedule keySched(AES::KeyLen::LEN_128, origKey);
 
@@ -118,7 +117,7 @@ namespace lskuse
 
     TEST(AESKeyScheduleTest, test192KeySchedule)
     {
-      char origKey[25];
+      char origKey[24];
       origKey[0] = 0x8e;
       origKey[1] = 0x73;
       origKey[2] = 0xb0;
@@ -143,7 +142,6 @@ namespace lskuse
       origKey[21] = 0x2c; 
       origKey[22] = 0x6b;
       origKey[23] = 0x7b;
-      origKey[24] = '\0';
 
       AESKeySchedule keySched(AES::KeyLen::LEN_192, origKey);
 
@@ -241,7 +239,7 @@ namespace lskuse
 
     TEST(AESKeyScheduleTest, test256KeySchedule)
     {
-      char origKey[33];
+      char origKey[32];
       origKey[0] = 0x60;
       origKey[1] = 0x3d;
       origKey[2] = 0xeb;
@@ -274,7 +272,6 @@ namespace lskuse
       origKey[29] = 0x14;
       origKey[30] = 0xdf;
       origKey[31] = 0xf4;
-      origKey[32] = '\0';
 
       AESKeySchedule keySched(AES::KeyLen::LEN_256, origKey);
 


### PR DESCRIPTION
Pass the key around as a char* so the caller of the library can pass any of the hex value between 0 and 225 inclusive for each byte of the key. As a consequence of this, we have to trust that callers will pass the correct length key.